### PR TITLE
Added keyboard navigation hook

### DIFF
--- a/gitcoin/ui/src/App.css
+++ b/gitcoin/ui/src/App.css
@@ -44,6 +44,16 @@
 .main-rows tr:nth-child(2n) {
   background-color: #f1f1f1;
 }
+.main-rows.no-hover .ant-table-tbody > tr.ant-table-row:hover > td {
+  background-color: transparent;
+}
+.main-rows .ant-table-tbody > tr.ant-table-row:hover > td {
+  background-color: rgb(248, 238, 225);
+}
+.main-rows .ant-table-tbody > tr.ant-table-row.selected > td,
+.main-rows.no-hover .ant-table-tbody > tr.ant-table-row.selected > td  {
+  background-color: antiquewhite;
+}
 .main-rows td {
   vertical-align: top;
 }

--- a/gitcoin/ui/src/App.css
+++ b/gitcoin/ui/src/App.css
@@ -37,12 +37,14 @@
   }
 }
 
-.main-rows tr:nth-child(2n+1) td, thead {
+.main-rows tr:nth-child(2n+1) {
   background-color: #fafafa;
-  vertical-align: top;
+
 }
-.main-rows tr:nth-child(2n) td, thead {
+.main-rows tr:nth-child(2n) {
   background-color: #f1f1f1;
+}
+.main-rows td {
   vertical-align: top;
 }
 .main-rows thead, th {

--- a/gitcoin/ui/src/BaseTable.jsx
+++ b/gitcoin/ui/src/BaseTable.jsx
@@ -1,26 +1,34 @@
 import { Table } from 'antd';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react/cjs/react.development';
 import { useKeyNav } from './useKeyNav';
 
 const pageSize = 10;
-const selectedRowStyle = {
-  color: 'darkblue',
-  backgroundColor: 'antiquewhite'
-};
 
 export function BaseTable(tableParams) {
   const tableWrapper = useRef();
-  const { page, row, keyNavOn } = useKeyNav({
+  const { page, row, keyNavOn, selectRow } = useKeyNav({
     pageSize,
     maxItems: tableParams.dataSource.length - 1
   });
+  const [mouseHoverBlocked, setMouseHoverBlocked] = useState(false);
+  // If the hover color is hidden, we want restore it as soon as
+  // the user moves their mouse.
+  const onMouseMove = useCallback(() => setMouseHoverBlocked(false), []);
+  const classes = useMemo(() => [
+    'main-rows',
+    mouseHoverBlocked ? 'no-hover' : '',
+  ].join(' '), [mouseHoverBlocked])
+  // We don't want to have hover color visible when using keyboard nav
+  useEffect(() => setMouseHoverBlocked(keyNavOn), [keyNavOn, row]);
 
   return (
     <div
       ref={tableWrapper}
+      onMouseMove={onMouseMove}
     >
       <Table
-        className='main-rows'
+        className={classes}
         size='small'
         bordered={true}
         pagination={{
@@ -33,7 +41,10 @@ export function BaseTable(tableParams) {
         }}
         onRow={(record, rowIndex) => {
           return {
-            style: keyNavOn && rowIndex === row ? selectedRowStyle : {},
+            onClick() {
+              selectRow(rowIndex)
+            },
+            className: keyNavOn && rowIndex === row ? 'selected' : '',
           };
         }}
         {...tableParams}

--- a/gitcoin/ui/src/BaseTable.jsx
+++ b/gitcoin/ui/src/BaseTable.jsx
@@ -5,7 +5,7 @@ import { useKeyNav } from './useKeyNav';
 const pageSize = 10;
 const selectedRowStyle = {
   color: 'darkblue',
-  backgroundColor: 'rgb(236, 235, 235)'
+  backgroundColor: 'antiquewhite'
 };
 
 export function BaseTable(tableParams) {

--- a/gitcoin/ui/src/BaseTable.jsx
+++ b/gitcoin/ui/src/BaseTable.jsx
@@ -1,0 +1,43 @@
+import { Table } from 'antd';
+import React, { useRef } from 'react';
+import { useKeyNav } from './useKeyNav';
+
+const pageSize = 10;
+const selectedRowStyle = {
+  color: 'darkblue',
+  backgroundColor: 'rgb(236, 235, 235)'
+};
+
+export function BaseTable(tableParams) {
+  const tableWrapper = useRef();
+  const { page, row, keyNavOn } = useKeyNav({
+    pageSize,
+    maxItems: tableParams.dataSource.length - 1
+  });
+
+  return (
+    <div
+      ref={tableWrapper}
+    >
+      <Table
+        className='main-rows'
+        size='small'
+        bordered={true}
+        pagination={{
+          size: 'small',
+          position: ['topRight', 'none'],
+          hideOnSinglePage: true,
+          showSizeChanger: false,
+          showTotal: (total, range) => '(' + total + ' grants) ',
+          current: page
+        }}
+        onRow={(record, rowIndex) => {
+          return {
+            style: keyNavOn && rowIndex === row ? selectedRowStyle : {},
+          };
+        }}
+        {...tableParams}
+      />
+      </div>
+  );
+}

--- a/gitcoin/ui/src/HomePage.jsx
+++ b/gitcoin/ui/src/HomePage.jsx
@@ -2,29 +2,19 @@ import React, { useEffect, useState } from 'react';
 import { useStatePersist } from 'use-state-persist';
 
 import { Input, Layout, Tabs } from 'antd';
-import { Table as AntTable } from 'antd';
 
 import './App.css';
 import 'antd/dist/antd.css';
 
 import { grantsData } from './grants-data';
 import { columns } from './ColumnDefs';
+import { BaseTable } from './BaseTable';
 
 import { DataForNerds } from './DataForNerds';
 
 const { Content } = Layout;
 const { Search } = Input;
 const { TabPane } = Tabs;
-const Table = (props) => {
-  const pag = {
-    size: 'small',
-    position: ['topRight', 'none'],
-    hideOnSinglePage: true,
-    showSizeChanger: false,
-    showTotal: (total, range) => '(' + total + ' grants) ',
-  };
-  return <AntTable className='main-rows' pagination={pag} size='small' bordered={true} {...props} />;
-};
 
 export const HomePage = () => {
   const [lastTab, setLastTab] = useStatePersist('@lastTab', 1);
@@ -71,10 +61,10 @@ export const HomePage = () => {
       </div>
       <Tabs defaultActiveKey={lastTab} onChange={tabSwitch} style={{ border: '1px dotted gray', padding: '1px' }}>
         <TabPane tab={tab2Title} key='1' style={{ paddingLeft: '8px', margin: '-25px 0px 0px 0px' }}>
-          <Table dataSource={grantData} columns={columns} />
+          <BaseTable dataSource={grantData} columns={columns} rowKey={(record) => record.grantId} />
         </TabPane>
         <TabPane tab={tab1Title} key='2' style={{ paddingLeft: '8px' }}>
-          <Table dataSource={contractData} columns={columns} />
+          <BaseTable dataSource={contractData} columns={columns} rowKey={(record) => record.grantId} />
         </TabPane>
         <TabPane tab={'Data for Nerds (API)'} key='3' style={{ paddingLeft: '8px' }}>
           <DataForNerds />

--- a/gitcoin/ui/src/useKeyNav.js
+++ b/gitcoin/ui/src/useKeyNav.js
@@ -35,11 +35,11 @@ export function useKeyNav({ pageSize, maxItems }) {
     return Math.max(0, Math.min(maxItems, currentPosition + addend));
   }, [maxItems]);
   // Handles the pressed key
-  const listener = useCallback(({ code }) => {
+  const listener = useCallback(({ key }) => {
     // Most of the time, arrow up or down will move by one item...
     let arrowUpAndDownAddend = 1;
 
-    if (navigationKeys.includes(code) && on === false) {
+    if (navigationKeys.includes(key) && on === false) {
       // ... but, if the navigation was "turned off" and the user
       // is turning it back on just now, we want to focus the first item
       // (which always has 0 index)
@@ -48,7 +48,7 @@ export function useKeyNav({ pageSize, maxItems }) {
     }
 
     /* eslint-disable default-case */
-    switch (code) {
+    switch (key) {
       case 'ArrowUp':
         setPosition(incrementPosition(-arrowUpAndDownAddend));
         break;
@@ -70,7 +70,6 @@ export function useKeyNav({ pageSize, maxItems }) {
         setPosition(0);
         break;
       case 'Escape':
-        setPosition(0);
         setOn(false);
         break;
     }

--- a/gitcoin/ui/src/useKeyNav.js
+++ b/gitcoin/ui/src/useKeyNav.js
@@ -1,0 +1,89 @@
+import { useEffect, useState, useCallback, useMemo } from 'react';
+
+const navigationKeys = [
+   'ArrowUp',
+   'ArrowDown',
+   'ArrowLeft',
+   'PageUp',
+   'ArrowRight',
+   'PageDown',
+   'End',
+   'Home',
+];
+
+// Adds keyboard navigation logic. The hook returns row and page
+// values that get increased/decreased when the arrow keys, page up,
+// page down, home and end keys are pressed.
+export function useKeyNav({ pageSize, maxItems }) {
+  // Position in the dataset. In a set of maxItems items, it can be
+  // an integer between 0 and maxItems.
+  const [position, setPosition] = useState(0);
+  // The navigation can be "turned off", which will not remove the
+  // listeners and the logic will still work, but the state can be
+  // presented as, for example, lack of highlight color.
+  const [on, setOn] = useState(false);
+  const page = useMemo(() => {
+    return Math.floor(position / pageSize) + 1;
+  }, [pageSize, position]);
+  const row = useMemo(() => {
+    return position % pageSize;
+  }, [pageSize, position]);
+
+  // Adds `addend` to `position`. To decrease the position value just use
+  // a negative `addend`.
+  const incrementPosition = useCallback((addend) => (currentPosition) => {
+    return Math.max(0, Math.min(maxItems, currentPosition + addend));
+  }, [maxItems]);
+  // Handles the pressed key
+  const listener = useCallback(({ code }) => {
+    // Most of the time, arrow up or down will move by one item...
+    let arrowUpAndDownAddend = 1;
+
+    if (navigationKeys.includes(code) && on === false) {
+      // ... but, if the navigation was "turned off" and the user
+      // is turning it back on just now, we want to focus the first item
+      // (which always has 0 index)
+      arrowUpAndDownAddend = 0;
+      setOn(true);
+    }
+
+    /* eslint-disable default-case */
+    switch (code) {
+      case 'ArrowUp':
+        setPosition(incrementPosition(-arrowUpAndDownAddend));
+        break;
+      case 'ArrowDown':
+        setPosition(incrementPosition(+arrowUpAndDownAddend));
+        break;
+      case 'ArrowLeft':
+      case 'PageUp':
+        setPosition(incrementPosition(-pageSize));
+        break;
+      case 'ArrowRight':
+      case 'PageDown':
+        setPosition(incrementPosition(+pageSize));
+        break;
+      case 'End':
+        setPosition(maxItems);
+        break;
+      case 'Home':
+        setPosition(0);
+        break;
+      case 'Escape':
+        setPosition(0);
+        setOn(false);
+        break;
+    }
+  }, [on, incrementPosition, pageSize, maxItems]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', listener);
+    return () => window.removeEventListener('keydown', listener);
+  }, [listener]);
+
+  return {
+    page,
+    row,
+    keyNavOn: on,
+  };
+}

--- a/gitcoin/ui/src/useKeyNav.js
+++ b/gitcoin/ui/src/useKeyNav.js
@@ -28,6 +28,13 @@ export function useKeyNav({ pageSize, maxItems }) {
   const row = useMemo(() => {
     return position % pageSize;
   }, [pageSize, position]);
+  // Let the component select a row. relativeRow is relative to the
+  // data currently loaded in the table, e.g. if we have 10 items loaded,
+  // the second item is 1 (we count from 0), even if it's 3rd page.
+  const selectRow = useCallback((relativeRow) => {
+    setOn(true);
+    setPosition((page-1) * pageSize + relativeRow);
+  }, [page, pageSize]);
 
   // Adds `addend` to `position`. To decrease the position value just use
   // a negative `addend`.
@@ -84,5 +91,6 @@ export function useKeyNav({ pageSize, maxItems }) {
     page,
     row,
     keyNavOn: on,
+    selectRow,
   };
 }


### PR DESCRIPTION
We can use `useKeyNav` hook in other places as well. It listens for the keys and sends back updated page and row values. It can also be "turned off" to remove the selection by pressing ESC