### PR TITLE
Bugfix/broken build table

### DIFF
--- a/gitcoin/ui/package.json
+++ b/gitcoin/ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
+    "@ant-design/icons": "^4.7.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
@@ -16,7 +17,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/gitcoin/ui/src/App.css
+++ b/gitcoin/ui/src/App.css
@@ -41,14 +41,20 @@
   font-family: monospace;
 }
 
-.main-rows tr:nth-child(2n+1) + td,
-.main-rows tr:nth-child(2n+1) + td.ant-table-column-sort {
+.main-rows tr:nth-child(2n+1) > td,
+.main-rows tr:nth-child(2n+1) > td.ant-table-column-sort {
   background-color: #fafafa;
 
 }
-.main-rows tr:nth-child(2n) + td,
-.main-rows tr:nth-child(2n) + td.ant-table-column-sort {
+.main-rows tr:nth-child(2n) > td,
+.main-rows tr:nth-child(2n) > td.ant-table-column-sort {
   background-color: #f1f1f1;
+}
+.main-rows.no-hover .ant-table-tbody > tr.ant-table-row:hover > td {
+  background-color: transparent;
+}
+.main-rows .ant-table-tbody > tr.ant-table-row:hover > td {
+  background-color: rgb(248, 238, 225);
 }
 .main-rows .ant-table-tbody > tr.ant-table-row.selected > td,
 .main-rows.no-hover .ant-table-tbody > tr.ant-table-row.selected > td  {
@@ -58,10 +64,9 @@
   vertical-align: top;
 }
 .main-rows thead, th {
-    background-color: #fafafa;
-    vertical-align: top;
+  background-color: #fafafa;
+  vertical-align: top;
 }
-
 .main-rows th .ant-table-column-title {
   white-space: nowrap;
 }

--- a/gitcoin/ui/src/App.css
+++ b/gitcoin/ui/src/App.css
@@ -37,11 +37,17 @@
   }
 }
 
-.main-rows tr:nth-child(2n+1) {
+.main-rows tbody {
+  font-family: monospace;
+}
+
+.main-rows tr:nth-child(2n+1) + td,
+.main-rows tr:nth-child(2n+1) + td.ant-table-column-sort {
   background-color: #fafafa;
 
 }
-.main-rows tr:nth-child(2n) {
+.main-rows tr:nth-child(2n) + td,
+.main-rows tr:nth-child(2n) + td.ant-table-column-sort {
   background-color: #f1f1f1;
 }
 .main-rows .ant-table-tbody > tr.ant-table-row.selected > td,
@@ -54,4 +60,8 @@
 .main-rows thead, th {
     background-color: #fafafa;
     vertical-align: top;
+}
+
+.main-rows th .ant-table-column-title {
+  white-space: nowrap;
 }

--- a/gitcoin/ui/src/App.css
+++ b/gitcoin/ui/src/App.css
@@ -1,3 +1,7 @@
+:root {
+  --color-highlight: antiquewhite;
+}
+
 .App {
   text-align: center;
 }
@@ -41,13 +45,13 @@
   font-family: monospace;
 }
 
-.main-rows tr:nth-child(2n+1) > td,
-.main-rows tr:nth-child(2n+1) > td.ant-table-column-sort {
+.main-rows .ant-table-content > table > tbody > tr:nth-child(2n+1) > td,
+.main-rows .ant-table-content > table > tbody > tr:nth-child(2n+1) > td.ant-table-column-sort {
   background-color: #fafafa;
 
 }
-.main-rows tr:nth-child(2n) > td,
-.main-rows tr:nth-child(2n) > td.ant-table-column-sort {
+.main-rows .ant-table-content > table > tbody > tr:nth-child(2n) > td,
+.main-rows .ant-table-content > table > tbody > tr:nth-child(2n) > td.ant-table-column-sort {
   background-color: #f1f1f1;
 }
 .main-rows.no-hover .ant-table-tbody > tr.ant-table-row:hover > td {
@@ -58,7 +62,7 @@
 }
 .main-rows .ant-table-tbody > tr.ant-table-row.selected > td,
 .main-rows.no-hover .ant-table-tbody > tr.ant-table-row.selected > td  {
-  background-color: antiquewhite;
+  background-color: var(--color-highlight);
 }
 .main-rows td {
   vertical-align: top;

--- a/gitcoin/ui/src/BaseTable.jsx
+++ b/gitcoin/ui/src/BaseTable.jsx
@@ -1,31 +1,58 @@
 import { Table } from 'antd';
-import React, { useRef, useState } from 'react';
-import { useEffect, useMemo } from 'react/cjs/react.development';
+import React, { useRef, useState, useCallback, useEffect, useMemo } from 'react';
+import { GrantDataRenderer } from './GrantDataRenderer';
 import { useKeyNav } from './useKeyNav';
 
 const pageSize = 10;
 
 export function BaseTable(tableParams) {
   const tableWrapper = useRef();
-  const { page, row, keyNavOn, selectRow } = useKeyNav({
+  const {
+    page,
+    row,
+    keyNavOn,
+    selectRow,
+    setPosition
+  } = useKeyNav({
     pageSize,
     maxItems: tableParams.dataSource.length - 1
   });
+  const [mouseHoverBlocked, setMouseHoverBlocked] = useState(false);
+  // If the hover color is hidden, we want restore it as soon as
+  // the user moves their mouse.
+  const onMouseMove = useCallback(() => setMouseHoverBlocked(false), []);
+  const classes = useMemo(() => [
+    'main-rows',
+    mouseHoverBlocked ? 'no-hover' : '',
+  ].join(' '), [mouseHoverBlocked])
+  // We don't want to have hover color visible when using keyboard nav
+  useEffect(() => setMouseHoverBlocked(keyNavOn), [keyNavOn, row]);
+
   return (
     <div
       ref={tableWrapper}
+      onMouseMove={onMouseMove}
     >
       <Table
-        className='main-rows'
+        className={classes}
         size='small'
         bordered={true}
+        expandable={{
+          columnWidth: "2%",
+          expandedRowRender(record) {
+            return <GrantDataRenderer grantData={record} />
+          }
+        }}
         pagination={{
           size: 'small',
           position: ['topRight', 'none'],
           hideOnSinglePage: true,
           showSizeChanger: false,
           showTotal: (total, range) => '(' + total + ' grants) ',
-          current: page
+          current: page,
+          onChange(page, pageSize) {
+            setPosition((page - 1) * pageSize);
+          },
         }}
         onRow={(record, rowIndex) => {
           return {

--- a/gitcoin/ui/src/ColumnCells.jsx
+++ b/gitcoin/ui/src/ColumnCells.jsx
@@ -13,15 +13,15 @@ export const DateHeader = () => (
 export const DateCell = ({ record }) => {
   const dd = (<div>
     {record.latestAppearance.date}
-    < div >
+    <div>
       <small>
         <i>
           {dateDisplay(record.latestAppearance.bn)}
         </i>
       </small>
       <div>{record.latestAppearance.timestamp}</div>
-    </div >
-  </div >
+    </div>
+  </div>
   );
   return <Cell2 text={dd} />;
 }
@@ -35,12 +35,12 @@ export const TagHeader = () => (
 )
 export const TagCell = ({ record }) => {
   return (<div style={{ marginTop: '-20px' }}>
-    <pre>
+    <div>
       <br />
       <Tag color='blue' key={record.address}>
         <small>{record.types}</small>
       </Tag>
-    </pre>
+    </div>
   </div>
   );
 }
@@ -79,21 +79,21 @@ export const NameCell = ({ record }) => {
 
   if (!record.slug)
     return (
-      <pre>
+      <div>
         <small>{name}</small> <ZipLink addr={record.address} />
         <br />
         {explorerLink}
-      </pre>
+      </div>
     );
   return (
     <div>
-      <pre>
+      <div>
         <a target={'top'} href={record.slug}>
           <small>{name}</small>
         </a> <ZipLink addr={record.address} />
         <br />
         {explorerLink}
-      </pre>
+      </div>
     </div>
   );
 }
@@ -179,9 +179,9 @@ const dateDisplay = (block) => {
 const Cell2 = ({ text }) => {
   return (
     <div>
-      <pre>
+      <div>
         <small>{text}</small>
-      </pre>
+      </div>
     </div>
   );
 };

--- a/gitcoin/ui/src/GrantDataRenderer.css
+++ b/gitcoin/ui/src/GrantDataRenderer.css
@@ -1,42 +1,48 @@
 .grant-data-renderer {
-    width: 80%;
-    margin: auto;
+  /* Match <small> font-size */
+  font-size: 80%;
+  margin: 16px calc(2% + 32px);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: 8px;
 }
 
 .grant-data-renderer table {
-    table-layout: fixed;
-    border: 1px solid rgb(217, 217, 217);
-    margin-top: 16px;
+  table-layout: fixed;
+  border: 1px solid rgb(217, 217, 217);
 }
 
 .grant-data-renderer table tr th,
 .grant-data-renderer table tr td {
-    padding: 8px;
-    vertical-align: middle;
+  padding: 8px;
+  vertical-align: middle;
 }
 
 .grant-data-renderer table tr:not(:last-child):not(.appearance-header) th,
 .grant-data-renderer table tr:not(:last-child) td {
-    border-bottom: 1px solid rgb(217, 217, 217);
+  border-bottom: 1px solid rgb(217, 217, 217);
 }
 
 .grant-data-renderer table tr:not(.appearance-details) th:not(:last-child),
 .grant-data-renderer table tr:not(.appearance-details) td:not(:last-child) {
-    border-right: 1px solid rgb(217, 217, 217);
+  border-right: 1px solid rgb(217, 217, 217);
 }
 
 .grant-data-renderer table th {
-    background-color: #f1f1f1;
+  background-color: var(--color-highlight);
 
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .grant-data-renderer table td {
-    background-color: #fafafa;
+  background-color: #fafafa;
 }
 
 .grant-data-renderer table ol {
-    margin: 0;
+  margin: 0;
 }

--- a/gitcoin/ui/src/GrantDataRenderer.css
+++ b/gitcoin/ui/src/GrantDataRenderer.css
@@ -27,6 +27,10 @@
 
 .grant-data-renderer table th {
     background-color: #f1f1f1;
+
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .grant-data-renderer table td {

--- a/gitcoin/ui/src/GrantDataRenderer.css
+++ b/gitcoin/ui/src/GrantDataRenderer.css
@@ -1,0 +1,38 @@
+.grant-data-renderer {
+    width: 80%;
+    margin: auto;
+}
+
+.grant-data-renderer table {
+    table-layout: fixed;
+    border: 1px solid rgb(217, 217, 217);
+    margin-top: 16px;
+}
+
+.grant-data-renderer table tr th,
+.grant-data-renderer table tr td {
+    padding: 8px;
+    vertical-align: middle;
+}
+
+.grant-data-renderer table tr:not(:last-child):not(.appearance-header) th,
+.grant-data-renderer table tr:not(:last-child) td {
+    border-bottom: 1px solid rgb(217, 217, 217);
+}
+
+.grant-data-renderer table tr:not(.appearance-details) th:not(:last-child),
+.grant-data-renderer table tr:not(.appearance-details) td:not(:last-child) {
+    border-right: 1px solid rgb(217, 217, 217);
+}
+
+.grant-data-renderer table th {
+    background-color: #f1f1f1;
+}
+
+.grant-data-renderer table td {
+    background-color: #fafafa;
+}
+
+.grant-data-renderer table ol {
+    margin: 0;
+}

--- a/gitcoin/ui/src/GrantDataRenderer.jsx
+++ b/gitcoin/ui/src/GrantDataRenderer.jsx
@@ -31,25 +31,25 @@ export function GrantDataRenderer({ grantData }) {
       <table>
         <tbody>
           <tr>
-            <th>
+            <th title='ID'>
               ID
             </th>
             <td>
               {grantData.grantId}
             </td>
-            <th>
+            <th title='Active?'>
               Active?
             </th>
             <td>
               {renderBoolean(grantData.active)}
             </td>
-            <th>
+            <th title='Core'>
               Core
             </th>
             <td>
             {renderBoolean(grantData.core)}
             </td>
-            <th>
+            <th title='Appearance count'>
               Appearance count
             </th>
             <td>
@@ -57,7 +57,7 @@ export function GrantDataRenderer({ grantData }) {
             </td>
           </tr>
           <tr>
-            <th>
+            <th title='Name'>
               Name
             </th>
             <td colSpan={7}>
@@ -65,14 +65,14 @@ export function GrantDataRenderer({ grantData }) {
             </td>
           </tr>
           <tr>
-            <th>
+            <th title='Address'>
               Address
             </th>
             <td colSpan={3}>
               {grantData.address}
               {renderCopyToClipboard(grantData.address)}
             </td>
-            <th>
+            <th title='Slug'>
               Slug
             </th>
             <td colSpan={3}>
@@ -81,30 +81,30 @@ export function GrantDataRenderer({ grantData }) {
             </td>
           </tr>
           <tr className='appearance-header'>
-            <th colSpan={8}>
+            <th title='First Appearance' colSpan={8}>
               First Appearance
             </th>
           </tr>
           <tr className='appearance-details'>
-            <th>
+            <th title='Block'>
               Block
             </th>
             <td>
               {grantData.firstAppearance.bn}
             </td>
-            <th>
+            <th title='Transaction ID'>
               Transaction ID
             </th>
             <td>
               {grantData.firstAppearance.txId}
             </td>
-            <th>
+            <th title='Timestamp'>
               Timestamp
             </th>
             <td>
               {grantData.firstAppearance.timestamp}
             </td>
-            <th>
+            <th title='Date'>
               Date
             </th>
             <td>
@@ -112,30 +112,30 @@ export function GrantDataRenderer({ grantData }) {
             </td>
           </tr>
           <tr className='appearance-header'>
-            <th colSpan={8}>
+            <th title='Latest Appearance' colSpan={8}>
               Latest Appearance
             </th>
           </tr>
           <tr className='appearance-details'>
-            <th>
+            <th title='Block'>
               Block
             </th>
             <td>
               {grantData.latestAppearance.bn}
             </td>
-            <th>
+            <th title='Transaction ID'>
               Transaction ID
             </th>
             <td>
               {grantData.latestAppearance.txId}
             </td>
-            <th>
+            <th title='Timestamp'>
               Timestamp
             </th>
             <td>
               {grantData.latestAppearance.timestamp}
             </td>
-            <th>
+            <th title='Date'>
               Date
             </th>
             <td>
@@ -143,25 +143,25 @@ export function GrantDataRenderer({ grantData }) {
             </td>
           </tr>
           <tr>
-            <th>
+            <th title='Last updated'>
               Last updated
             </th>
             <td>
               {grantData.lastUpdated}
             </td>
-            <th>
+            <th title='Block range'>
               Block range
             </th>
             <td>
               {grantData.blockRange}
             </td>
-            <th>
+            <th title='File size'>
               File size
             </th>
             <td>
               {grantData.fileSize}
             </td>
-            <th>
+            <th title='Log count'>
               Log count
             </th>
             <td>
@@ -169,13 +169,13 @@ export function GrantDataRenderer({ grantData }) {
             </td>
           </tr>
           <tr>
-            <th>
+            <th title='Neighbor count'>
               Neighbor count
             </th>
             <td>
               {grantData.neighborCount}
             </td>
-            <th>
+            <th title='Types'>
               Types
             </th>
             <td colSpan={5}>
@@ -183,7 +183,7 @@ export function GrantDataRenderer({ grantData }) {
             </td>
           </tr>
           <tr>
-            <th>
+            <th title='Balances'>
               Balances
             </th>
             <td colSpan={3}>
@@ -191,13 +191,13 @@ export function GrantDataRenderer({ grantData }) {
                 {grantData.balances.map((balance) => <li key={balance.asset}>{balance.asset} {balance.balance}</li>)}
               </ol>
             </td>
-            <th>
+            <th title='Matched'>
               Matched
             </th>
             <td>
               {grantData.matched}
             </td>
-            <th>
+            <th title='Claimed'>
               Claimed
             </th>
             <td>

--- a/gitcoin/ui/src/GrantDataRenderer.jsx
+++ b/gitcoin/ui/src/GrantDataRenderer.jsx
@@ -76,8 +76,13 @@ export function GrantDataRenderer({ grantData }) {
               Slug
             </th>
             <td colSpan={3}>
-              {grantData.slug}
-              {renderCopyToClipboard(grantData.slug)}
+              {grantData.slug
+                ? (<>
+                  {grantData.slug}
+                  {renderCopyToClipboard(grantData.slug)}
+                </>)
+                : null
+              }
             </td>
           </tr>
           <tr className='appearance-header'>

--- a/gitcoin/ui/src/GrantDataRenderer.jsx
+++ b/gitcoin/ui/src/GrantDataRenderer.jsx
@@ -27,7 +27,6 @@ export function GrantDataRenderer({ grantData }) {
 
   return (
     <section className='grant-data-renderer'>
-      {renderCopyToClipboard(JSON.stringify(grantData), 'Copy as JSON', '')}
       <table>
         <tbody>
           <tr>
@@ -211,6 +210,7 @@ export function GrantDataRenderer({ grantData }) {
           </tr>
         </tbody>
       </table>
+      {renderCopyToClipboard(JSON.stringify(grantData), 'Copy as JSON', '')}
     </section>
   );
 }

--- a/gitcoin/ui/src/GrantDataRenderer.jsx
+++ b/gitcoin/ui/src/GrantDataRenderer.jsx
@@ -1,0 +1,211 @@
+import React from 'react';
+
+import {
+  CheckCircleTwoTone,
+  CloseCircleTwoTone,
+  CopyTwoTone,
+} from '@ant-design/icons'
+import { Button, Tag, Tooltip } from 'antd';
+
+import './GrantDataRenderer.css';
+
+export function GrantDataRenderer({ grantData }) {
+  const renderBoolean = (boolean) => boolean
+    ? <Tooltip title="Yes"><CheckCircleTwoTone twoToneColor="#52c41a" /></Tooltip>
+    : <Tooltip title="No"><CloseCircleTwoTone twoToneColor="#eb2f96" /></Tooltip>
+  const renderCopyToClipboard = (textToCopy, label, type = "text") => (
+    <Button
+      type={type}
+      onClick={() => {
+        navigator.clipboard.writeText(textToCopy);
+      }}
+    >
+      {label ?? null}
+      <CopyTwoTone />
+    </Button>
+  );
+
+  return (
+    <section className='grant-data-renderer'>
+      {renderCopyToClipboard(JSON.stringify(grantData), 'Copy as JSON', '')}
+      <table>
+        <tbody>
+          <tr>
+            <th>
+              ID
+            </th>
+            <td>
+              {grantData.grantId}
+            </td>
+            <th>
+              Active?
+            </th>
+            <td>
+              {renderBoolean(grantData.active)}
+            </td>
+            <th>
+              Core
+            </th>
+            <td>
+            {renderBoolean(grantData.core)}
+            </td>
+            <th>
+              Appearance count
+            </th>
+            <td>
+              {grantData.appearanceCount}
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Name
+            </th>
+            <td colSpan={7}>
+              {grantData.name}
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Address
+            </th>
+            <td colSpan={3}>
+              {grantData.address}
+              {renderCopyToClipboard(grantData.address)}
+            </td>
+            <th>
+              Slug
+            </th>
+            <td colSpan={3}>
+              {grantData.slug}
+              {renderCopyToClipboard(grantData.slug)}
+            </td>
+          </tr>
+          <tr className='appearance-header'>
+            <th colSpan={8}>
+              First Appearance
+            </th>
+          </tr>
+          <tr className='appearance-details'>
+            <th>
+              Block
+            </th>
+            <td>
+              {grantData.firstAppearance.bn}
+            </td>
+            <th>
+              Transaction ID
+            </th>
+            <td>
+              {grantData.firstAppearance.txId}
+            </td>
+            <th>
+              Timestamp
+            </th>
+            <td>
+              {grantData.firstAppearance.timestamp}
+            </td>
+            <th>
+              Date
+            </th>
+            <td>
+              {grantData.firstAppearance.date}
+            </td>
+          </tr>
+          <tr className='appearance-header'>
+            <th colSpan={8}>
+              Latest Appearance
+            </th>
+          </tr>
+          <tr className='appearance-details'>
+            <th>
+              Block
+            </th>
+            <td>
+              {grantData.latestAppearance.bn}
+            </td>
+            <th>
+              Transaction ID
+            </th>
+            <td>
+              {grantData.latestAppearance.txId}
+            </td>
+            <th>
+              Timestamp
+            </th>
+            <td>
+              {grantData.latestAppearance.timestamp}
+            </td>
+            <th>
+              Date
+            </th>
+            <td>
+              {grantData.latestAppearance.date}
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Last updated
+            </th>
+            <td>
+              {grantData.lastUpdated}
+            </td>
+            <th>
+              Block range
+            </th>
+            <td>
+              {grantData.blockRange}
+            </td>
+            <th>
+              File size
+            </th>
+            <td>
+              {grantData.fileSize}
+            </td>
+            <th>
+              Log count
+            </th>
+            <td>
+              {grantData.logCount}
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Neighbor count
+            </th>
+            <td>
+              {grantData.neighborCount}
+            </td>
+            <th>
+              Types
+            </th>
+            <td colSpan={5}>
+              {grantData.types.split(',').map((type) => <Tag key={type}>{type}</Tag>)}
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Balances
+            </th>
+            <td colSpan={3}>
+              <ol>
+                {grantData.balances.map((balance) => <li key={balance.asset}>{balance.asset} {balance.balance}</li>)}
+              </ol>
+            </td>
+            <th>
+              Matched
+            </th>
+            <td>
+              {grantData.matched}
+            </td>
+            <th>
+              Claimed
+            </th>
+            <td>
+              {grantData.claimed}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/gitcoin/ui/src/Utils.jsx
+++ b/gitcoin/ui/src/Utils.jsx
@@ -3,7 +3,7 @@ import { DownloadOutlined } from '@ant-design/icons';
 export const DownloadIcon = ({ address, count, path }) => {
   return (
     <div style={{ display: 'grid', gridTemplateColumns: '1fr' }}>
-      <pre style={{ margin: '0px' }}>
+      <div style={{ margin: '0px' }}>
         <small>({count})</small>
         <br />
         <small>
@@ -11,7 +11,7 @@ export const DownloadIcon = ({ address, count, path }) => {
             <DownloadOutlined /> {"csv"}
           </a>
         </small>
-      </pre>
+      </div>
     </div>
   );
 }

--- a/gitcoin/ui/src/useKeyNav.js
+++ b/gitcoin/ui/src/useKeyNav.js
@@ -92,5 +92,6 @@ export function useKeyNav({ pageSize, maxItems }) {
     row,
     keyNavOn: on,
     selectRow,
+    setPosition,
   };
 }


### PR DESCRIPTION
- Fixed `yarn build`
- Decreased build time a little bit
- Added grant details (but ❌ no expand when Enter pressed due to Ant Design's limitation)
- Fixed row background colors when sorting
- Fixed table headers so that the text is not wrapped

⚠️ Having expandable rows breaks even/odd row background. When a row is expanded, Ant Design adds another row to a table (this is the "expanded" content) confusing the browser which row is even and which is odd. I left this bug for now, so you can test it and decide if we should make the backgrounds same color.