### PR TITLE
Fixes #32, fixes #31

### DIFF
--- a/gitcoin/ui/src/ColumnCells.jsx
+++ b/gitcoin/ui/src/ColumnCells.jsx
@@ -33,7 +33,7 @@ export const NameHeader = () => (
     tooltip='The name and address of the grant or core contract.'
   />
 )
-export const NameCell = ({ grantData }) => {
+export const NameCell = ({ grantData, overrideName }) => {
   const [copied, setCopied] = useState(false);
   const { localExplorer } = useGlobalState();
 
@@ -63,14 +63,17 @@ export const NameCell = ({ grantData }) => {
     "/" +
     grantData.name.replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
 
-  if (!slug)
+  if (!slug || overrideName) {
+    const nameToShow = overrideName || name;
     return (
       <div>
-        {name} <ZipLink grantData={grantData} />
+        {nameToShow} <ZipLink grantData={grantData} />
         <br />
         {explorerLink}
       </div>
     );
+  }
+
   return (
     <div>
       <div>
@@ -128,7 +131,7 @@ export const NeighborsHeader = () => (
 export const SuspiciousHeader = () => (
   <ColumnTitle
     title='Suspicious'
-    tooltip='Does this address looks suspicious?'
+    tooltip='Does this address look suspicious?'
   />
 )
 

--- a/gitcoin/ui/src/ColumnDefs.jsx
+++ b/gitcoin/ui/src/ColumnDefs.jsx
@@ -2,6 +2,9 @@ import { DownloadIcon } from './Utils';
 import { DateHeader, DateCell, NameHeader, NameCell, BalanceHeader, AppearanceHeader, TransactionHeader, EventLogsHeader, NeighborsHeader, SuspiciousHeader } from "./ColumnCells"
 import { getChainData } from './GlobalState';
 
+// To mocked predicate to tell if an address is suspicious
+const mockedIsSuspicious = (index) => (index + 1) % 5 === 0;
+
 export const columns = [
   {
     title: <DateHeader />,
@@ -27,8 +30,12 @@ export const columns = [
     sorter: {
       compare: (a, b) => a.address - b.address,
     },
-    render: function (u, grantData) {
-      return <NameCell grantData={grantData} />
+    render: function (u, grantData, index) {
+      const overrideName = mockedIsSuspicious(index)
+        ? "Name has been changed to protect the innocent"
+        : false;
+
+      return <NameCell grantData={grantData} overrideName={overrideName} />
     },
   },
   {
@@ -142,8 +149,9 @@ export const columns = [
   },
   {
     title: <SuspiciousHeader />,
+    width: '2%',
     render(text, record, index) {
-      const icon = (index + 1) % 5 === 0
+      const icon = mockedIsSuspicious(index)
         ? <span>😡</span>
         : null;
 

--- a/giveth/ui/src/ColumnCells.jsx
+++ b/giveth/ui/src/ColumnCells.jsx
@@ -33,7 +33,7 @@ export const NameHeader = () => (
     tooltip='The name and address of the grant or core contract.'
   />
 )
-export const NameCell = ({ grantData }) => {
+export const NameCell = ({ grantData, overrideName }) => {
   const [copied, setCopied] = useState(false);
   const { localExplorer } = useGlobalState();
 
@@ -63,14 +63,17 @@ export const NameCell = ({ grantData }) => {
     "/" +
     grantData.name.replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, '-').replace(/-+/g, '-');
 
-  if (!slug)
+  if (!slug || overrideName) {
+    const nameToShow = overrideName || name;
     return (
       <div>
-        {name} <ZipLink grantData={grantData} />
+        {nameToShow} <ZipLink grantData={grantData} />
         <br />
         {explorerLink}
       </div>
     );
+  }
+
   return (
     <div>
       <div>
@@ -128,7 +131,7 @@ export const NeighborsHeader = () => (
 export const SuspiciousHeader = () => (
   <ColumnTitle
     title='Suspicious'
-    tooltip='Does this address looks suspicious?'
+    tooltip='Does this address look suspicious?'
   />
 )
 

--- a/giveth/ui/src/ColumnDefs.jsx
+++ b/giveth/ui/src/ColumnDefs.jsx
@@ -2,6 +2,9 @@ import { DownloadIcon } from './Utils';
 import { DateHeader, DateCell, NameHeader, NameCell, BalanceHeader, AppearanceHeader, TransactionHeader, EventLogsHeader, NeighborsHeader, SuspiciousHeader } from "./ColumnCells"
 import { getChainData } from './GlobalState';
 
+// To mocked predicate to tell if an address is suspicious
+const mockedIsSuspicious = (index) => (index + 1) % 5 === 0;
+
 export const columns = [
   {
     title: <DateHeader />,
@@ -27,8 +30,12 @@ export const columns = [
     sorter: {
       compare: (a, b) => a.address - b.address,
     },
-    render: function (u, grantData) {
-      return <NameCell grantData={grantData} />
+    render: function (u, grantData, index) {
+      const overrideName = mockedIsSuspicious(index)
+        ? "Name has been changed to protect the innocent"
+        : false;
+
+      return <NameCell grantData={grantData} overrideName={overrideName} />
     },
   },
   {
@@ -142,8 +149,9 @@ export const columns = [
   },
   {
     title: <SuspiciousHeader />,
+    width: '2%',
     render(text, record, index) {
-      const icon = (index + 1) % 5 === 0
+      const icon = mockedIsSuspicious(index)
         ? <span>😡</span>
         : null;
 


### PR DESCRIPTION
Fixes for the two issues.
When the name is removed (because of the address being suspicious), it is no longer a link, but normal text (slug in the URL would make replacing the name pointless).
![Zrzut ekranu 2022-06-24 o 09 34 03](https://user-images.githubusercontent.com/2346536/175493476-cc0cf832-ec72-40f5-8e72-728bae4f560c.png)

